### PR TITLE
Move a faixa com o título do vídeo abaixo do player

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -144,7 +144,7 @@ nav ul li a.active::after {
     background-color: rgba(15, 52, 96, 0.9);
     color: var(--light-color);
     padding: 0.5rem 1rem;
-    position: absolute;
+    position: relative;
     bottom: 0;
     left: 0;
     width: 100%;

--- a/index.html
+++ b/index.html
@@ -27,9 +27,6 @@
         <div class="player-container">
             <div id="live-player"></div>
             <div class="player-status" id="player-status">AO VIVO</div>
-            <div class="now-playing">
-                <h3 id="current-video-title">Carregando...</h3>
-            </div>
             <div class="player-controls">
                 <button id="toggle-mute" class="control-button">
                     <span class="mute-icon">🔊</span>
@@ -38,6 +35,9 @@
                     <input type="range" id="volume-slider" min="0" max="100" value="100" class="volume-slider">
                 </div>
             </div>
+        </div>
+        <div class="now-playing">
+            <h3 id="current-video-title">Carregando...</h3>
         </div>
     </div>
     


### PR DESCRIPTION
A faixa com o título do vídeo ocupa bastante espaço do player, prejudicando a visualização do vídeo em si, principalmente quando a página é aberta no celular.

Este patch corrige o problema movendo a faixa para baixo, fora do player.

Resolve o problema #3 