### PR TITLE
Corrige layout do botão do YouTube para mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -212,6 +212,17 @@ nav ul li a.active::after {
     background-color: var(--secondary-color);
 }
 
+.subscribe-section {
+    margin: 1rem;
+    height: 96px;
+}
+
+/* override YouTube subscribe iframe size 167x48 */
+div.subscribe-button div iframe {
+    width: auto !important;
+    height: auto !important;
+}
+
 .more-content {
     text-align: center;
     padding: 0.8rem 1.5rem;

--- a/index.html
+++ b/index.html
@@ -40,9 +40,11 @@
             <h3 id="current-video-title">Carregando...</h3>
         </div>
 
-        <h3>Inscreva-se no nosso canal do Youtube</h3>
-        <script src="https://apis.google.com/js/platform.js"></script>
-        <div class="g-ytsubscribe" data-channelid="UC4lyNJeXfZirWKlvMtKLRzg" data-layout="full" data-count="default"></div>
+        <div class="subscribe-section">
+            <h3>Inscreva-se no nosso canal do Youtube</h3>
+            <script src="https://apis.google.com/js/platform.js"></script>
+            <div class="g-ytsubscribe" data-channelid="UC4lyNJeXfZirWKlvMtKLRzg" data-layout="full" data-count="default"></div>
+        </div>
 
     </div>
 


### PR DESCRIPTION
O botão do YouTube para se inscrever no canal insere um iframe de 167x48 px
que acaba cortando quando se usa `data-layout="full"` (inclui o logo do canal).

Este patch corrige sobrescrevendo os atributos de altura e largura no CSS.

Implementa #7 