### PR TITLE
Remove o espaçamento na parte superior do player

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -119,7 +119,6 @@ nav ul li a.active::after {
     border-radius: 8px;
     overflow: hidden;
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.08);
-    margin-top: 30px;
 }
 
 .player-container {
@@ -772,7 +771,6 @@ nav ul li a.active::after {
 
     .player-section {
         width: 100%;
-        margin-top: 120px;
         border-radius: 0;
     }
 
@@ -823,10 +821,6 @@ nav ul li a.active::after {
     
     nav ul li a {
         font-size: 0.9rem;
-    }
-    
-    .player-section {
-        margin-top: 150px;
     }
     
     .slider-arrow {


### PR DESCRIPTION
O botão `Outros programas e mais informações, clique aqui` fica escondido até o usuário rolar a página para baixo.

Este patch remove o espaçamento na parte superior do player para que o botão fique sempre visível.