### PR TITLE
Elimina a necessidade de rolar a página no celular

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -28,7 +28,8 @@ body {
     line-height: 1.6;
     display: flex;
     flex-direction: column;
-    min-height: 100vh;
+    height: 100vh;
+    height: 100dvh;
 }
 
 header {
@@ -52,7 +53,7 @@ header {
     display: flex;
     flex-direction: column;
     padding: 10px;
-    max-height: calc(100vh - 60px);
+    max-height: calc(100dvh - 60px);
     /* Ajustado para altura do header */
     overflow-y: auto;
 }


### PR DESCRIPTION
Atualmente, a página exige scroll para exibir o botão na página inicial.
A unidade vh (viewport height) leva em consideração a altura da barra de endereço, que coincide com a altura do botão no final da página.

Este patch corrige o problema utilizando a unidade dvh (dynamic viewport height), que se adapta conforme a barra de endereço estiver exposta ou oculta.